### PR TITLE
truncate core services so they are not recreated by xbps updates

### DIFF
--- a/install
+++ b/install
@@ -163,11 +163,12 @@ XBPS_ARCH=$ARCH "$bindir/xbps-install.static" -yMU \
 
 chroot "$INSTALL_DIR" xbps-reconfigure -a
 
-echo "==> Removing unecessary runit services"
-rm -f "$INSTALL_DIR/etc/runit/core-services/01-static-devnodes.sh"
-rm -f "$INSTALL_DIR/etc/runit/core-services/02-kmods.sh"
-rm -f "$INSTALL_DIR/etc/runit/core-services/02-udev.sh"
-rm -f "$INSTALL_DIR/etc/runit/core-services/03-filesystems.sh"
+echo "==> Clearing unecessary runit services"
+msg='# cleared by void-lx-brand-image-builder'
+echo "$msg" > "$INSTALL_DIR/etc/runit/core-services/01-static-devnodes.sh"
+echo "$msg" > "$INSTALL_DIR/etc/runit/core-services/02-kmods.sh"
+echo "$msg" > "$INSTALL_DIR/etc/runit/core-services/02-udev.sh"
+echo "$msg" > "$INSTALL_DIR/etc/runit/core-services/03-filesystems.sh"
 
 echo "==> linking required runit services"
 chroot "$INSTALL_DIR" ln -s /etc/sv/sshd /etc/runit/runsvdir/default


### PR DESCRIPTION
I ran into an issue where my zone was unable to boot after running `xbps-install -Syu`.  Looking into the console logs, it got itself into an issue where it failed somewhere trying to initialize udev.  I eventually tracked this down to the core services being recreated by xbps after I updated.

The fix for this is simple - clear the files out instead of removing them when building the image so they will not be modified by any subsequent upgrades.

Note - If you have hit this issue, or would like to avoid hitting this issue, you can clean the files out manually on a running zone to ensure they won't be touched by `xbps` updates:

```
cd /etc/runit/core-services/
for f in 01-static-devnodes.sh 02-kmods.sh 02-udev.sh 03-filesystems.sh ; do > "$f"; done 
```

FWIW, the package in question that is responsible for these files is `runit-void`

```
bash-5.0# xlocate 01-static-devnodes.sh 
runit-void-20200720_1   /etc/runit/core-services/01-static-devnodes.sh
```